### PR TITLE
Remove the password length limit

### DIFF
--- a/example/lib/token_page.dart
+++ b/example/lib/token_page.dart
@@ -66,8 +66,6 @@ class _TokenPageState extends State<TokenPage> {
                 validator: (input) {
                   if (input == null || input.isEmpty) {
                     return 'Password cannot be empty';
-                  } else if (input.length < 6) {
-                    return 'Password must be longer than 5 characters';
                   }
                   return null;
                 },


### PR DESCRIPTION
Remove "else if" in the validator to enable any password length with getting a new token
I think this would be enough:
```dart
validator: (input) {
    if (input == null || input.isEmpty) {
            return 'Password cannot be empty';
    }
    return null;
},
```